### PR TITLE
SC-87_REF_SS_Split_Join_Payment

### DIFF
--- a/packages/hardhat/contracts/Cuchulink.sol
+++ b/packages/hardhat/contracts/Cuchulink.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract CuchulinkMvp {
+contract Cuchulink {
 
     struct Participant {
         bool hasPaid;

--- a/packages/hardhat/contracts/Cuchulink.sol
+++ b/packages/hardhat/contracts/Cuchulink.sol
@@ -1,257 +1,213 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-contract Cuchulink {
-	struct Participant {
-		bool hasPaid;
-		uint256 totalPaid;
-	}
+contract CuchulinkMvp {
 
-	struct Round {
-		address winner;
-		bool hasWinner;
-	}
+    struct Participant {
+        bool hasPaid;
+        uint256 totalPaid;
+        bool hasJoined;
+    }
 
-	struct Cuchubal {
-		string nombre;
-		uint256 montoPorRonda; // Monto en Wei
-		uint256 fechaInicio;
-		uint256 fechaFinalizacion;
-		uint256 numParticipantes;
-		uint256 rondaActual;
-		uint256 participantesPagados;
-		mapping(address => Participant) participants;
-		mapping(uint256 => Round) rounds; // Historial de rondas
-		mapping(uint256 => address) participantIndex;
-	}
+    struct Round {
+        address winner;
+        bool hasWinner;
+    }
 
-	mapping(string => Cuchubal) private cuchubales;
-	mapping(address => string[]) private creatorToCuchubales;
+    struct Cuchubal {
+        string nombre;
+        uint256 montoPorRonda; // Monto en Wei
+        uint256 numParticipantes;
+        uint256 rondaActual;
+        uint256 participantesPagados;
+        uint256 participantesRegistrados;
+        bool exists;
+        mapping(address => Participant) participants;
+        mapping(uint256 => Round) rounds; // Historial de rondas
+        mapping(uint256 => address) participantIndex;
+    }
 
-	event CuchubalCreated(
-		string codigo,
-		string nombre,
-		uint256 montoPorRonda,
-		uint256 fechaInicio,
-		uint256 numParticipantes,
-		address creador
-	);
-	event ParticipantJoined(string codigo, address participant);
-	event PaymentMade(string codigo, address participant, uint256 amount);
-	event RoundCompleted(string codigo, uint256 rondaActual, address winner);
+    mapping(string => Cuchubal) private cuchubales;
+    mapping(address => string[]) private creatorToCuchubales;
 
-	modifier onlyCreator(string memory codigo) {
-		require(
-			cuchubales[codigo].participants[msg.sender].hasPaid,
-			"Only creator can call this function"
-		);
-		_;
-	}
+    event CuchubalCreated(
+        string codigo,
+        string nombre,
+        uint256 montoPorRonda,
+        uint256 numParticipantes,
+        address creador
+    );
+    event ParticipantJoined(string codigo, address participant);
+    event PaymentMade(string codigo, address participant, uint256 amount);
+    event RoundCompleted(string codigo, uint256 rondaActual, address winner);
 
-	modifier onlyParticipant(string memory codigo) {
-		require(
-			cuchubales[codigo].participants[msg.sender].hasPaid,
-			"Only participants can call this function"
-		);
-		_;
-	}
+    modifier onlyCreator(string memory codigo) {
+        require(cuchubales[codigo].participants[msg.sender].hasPaid, "Only creator can call this function");
+        _;
+    }
 
-	function createCuchubal(
-		string memory nombre,
-		uint256 montoPorRonda, // En Wei
-		uint256 fechaInicio,
-		uint256 numParticipantes,
-		string memory codigo
-	) public payable {
-		require(
-			msg.value == montoPorRonda,
-			"Initial payment must be equal to montoPorRonda"
-		);
+    modifier onlyParticipant(string memory codigo) {
+        require(cuchubales[codigo].participants[msg.sender].hasPaid, "Only participants can call this function");
+        _;
+    }
 
-		Cuchubal storage newCuchubal = cuchubales[codigo];
-		newCuchubal.nombre = nombre;
-		newCuchubal.montoPorRonda = montoPorRonda;
-		newCuchubal.fechaInicio = fechaInicio;
-		newCuchubal.fechaFinalizacion =
-			fechaInicio +
-			(2 * numParticipantes * 1 weeks);
-		newCuchubal.numParticipantes = numParticipantes;
-		newCuchubal.rondaActual = 1;
-		newCuchubal.participantesPagados = 1;
-		newCuchubal.participants[msg.sender] = Participant({
-			hasPaid: true,
-			totalPaid: msg.value
-		});
-		newCuchubal.rounds[newCuchubal.rondaActual] = Round({
-			winner: address(0),
-			hasWinner: false
-		});
-		newCuchubal.participantIndex[newCuchubal.participantesPagados] = msg
-			.sender;
+    function createCuchubal(
+        string memory nombre,
+        uint256 montoPorRonda, // En Wei
+        uint256 numParticipantes,
+        string memory codigo
+    ) public payable {
+        require(!cuchubales[codigo].exists, "Cuchubal with this code already exists");
+        require(msg.value == montoPorRonda, "Initial payment must be equal to montoPorRonda");
 
-		creatorToCuchubales[msg.sender].push(codigo);
+        Cuchubal storage newCuchubal = cuchubales[codigo];
+        newCuchubal.nombre = nombre;
+        newCuchubal.exists = true;
+        newCuchubal.montoPorRonda = montoPorRonda;
+        newCuchubal.numParticipantes = numParticipantes;
+        newCuchubal.rondaActual = 1;
+        newCuchubal.participantesPagados = 1;
+        newCuchubal.participants[msg.sender] = Participant({hasPaid: true, hasJoined: true, totalPaid: msg.value});
+        newCuchubal.rounds[newCuchubal.rondaActual] = Round({winner: address(0), hasWinner: false});
+        newCuchubal.participantIndex[newCuchubal.participantesPagados] = msg.sender;
 
-		emit CuchubalCreated(
-			codigo,
-			nombre,
-			montoPorRonda,
-			fechaInicio,
-			numParticipantes,
-			msg.sender
-		);
-		emit PaymentMade(codigo, msg.sender, msg.value);
-	}
+        creatorToCuchubales[msg.sender].push(codigo);
 
-	function joinCuchubal(string memory codigo) public payable {
-		Cuchubal storage cuchubal = cuchubales[codigo];
-		require(cuchubal.fechaInicio != 0, "Cuchubal not found");
+        emit CuchubalCreated(codigo, nombre, montoPorRonda, numParticipantes, msg.sender);
+        emit PaymentMade(codigo, msg.sender, msg.value);
+    }
 
-		Participant storage participant = cuchubal.participants[msg.sender];
-		bool isNewParticipant = !participant.hasPaid;
-		require(
-			isNewParticipant || cuchubal.rondaActual > 1,
-			"You have already paid for this round"
-		);
-		require(
-			cuchubal.participantesPagados < cuchubal.numParticipantes,
-			"Cuchubal is full"
-		);
-		require(
-			msg.value == cuchubal.montoPorRonda,
-			"Payment must be equal to montoPorRonda"
-		);
+    function joinCuchubal(string memory codigo) public payable {
+        Cuchubal storage cuchubal = cuchubales[codigo];
+        //require(cuchubal.fechaInicio != 0, "Cuchubal not found");
 
-		if (isNewParticipant) {
-			cuchubal.participants[msg.sender] = Participant({
-				hasPaid: true,
-				totalPaid: msg.value
-			});
-			cuchubal.participantesPagados++;
-			cuchubal.participantIndex[cuchubal.participantesPagados] = msg
-				.sender;
-		} else {
-			participant.hasPaid = true;
-			participant.totalPaid += msg.value;
-		}
+        Participant storage participant = cuchubal.participants[msg.sender];
+        require(!participant.hasJoined, "You are already registered in this Cuchubal");
+        require(cuchubal.participantesRegistrados < cuchubal.numParticipantes, "Cuchubal is full");
+        require(msg.value == cuchubal.montoPorRonda, "Payment must be equal to montoPorRonda");
 
-		emit ParticipantJoined(codigo, msg.sender);
-		emit PaymentMade(codigo, msg.sender, msg.value);
+        cuchubal.participants[msg.sender] = Participant({hasPaid: true, hasJoined: true, totalPaid: msg.value});
 
-		if (cuchubal.participantesPagados == cuchubal.numParticipantes) {
-			distributePayment(codigo);
-		}
-	}
+        cuchubal.participantesRegistrados++;
+        cuchubal.participantesPagados++;
+        cuchubal.participantIndex[cuchubal.participantesPagados] = msg.sender;
 
-	function distributePayment(string memory codigo) private {
-		Cuchubal storage cuchubal = cuchubales[codigo];
-		uint256 totalAmount = cuchubal.montoPorRonda *
-			cuchubal.numParticipantes;
+        emit ParticipantJoined(codigo, msg.sender);
+        emit PaymentMade(codigo, msg.sender, msg.value);
 
-		// Seleccionar ganador
-		if (cuchubal.participantesPagados == cuchubal.numParticipantes) {
-			uint256 randIndex = uint256(
-				keccak256(abi.encodePacked(block.timestamp, block.difficulty))
-			) % cuchubal.numParticipantes;
-			address winner = cuchubal.participantIndex[randIndex + 1]; // Índice comienza en 1
+        if (cuchubal.participantesPagados == cuchubal.numParticipantes) {
+            distributePayment(codigo);
+        }
+    }
 
-			// Transferir al ganador
-			(bool success, ) = payable(winner).call{ value: totalAmount }("");
-			require(success, "Transfer failed.");
+    function payForNextRound(string memory codigo) public payable {
+        Cuchubal storage cuchubal = cuchubales[codigo];
+        //require(cuchubal.rondaActual > 1, "Next round payments not started yet");
+        require(cuchubal.rondaActual != 1, "Cannot pay for the next round yet");
+        require(!cuchubal.participants[msg.sender].hasPaid, "You have already paid for this round");
+        require(cuchubal.numParticipantes != cuchubal.rondaActual, "Cuchulink has finished");
+        require(msg.value == cuchubal.montoPorRonda, "Payment must be equal to montoPorRonda");
 
-			cuchubal.rounds[cuchubal.rondaActual] = Round({
-				winner: winner,
-				hasWinner: true
-			});
-			emit RoundCompleted(codigo, cuchubal.rondaActual, winner);
+        cuchubal.participants[msg.sender].hasPaid = true;
+        cuchubal.participants[msg.sender].totalPaid += msg.value;
+        cuchubal.participantesPagados++;
 
-			// Restablecer pagos para la siguiente ronda
-			for (uint256 i = 1; i <= cuchubal.numParticipantes; i++) {
-				address participantAddr = cuchubal.participantIndex[i];
-				cuchubal.participants[participantAddr].hasPaid = false;
-			}
+        emit PaymentMade(codigo, msg.sender, msg.value);
 
-			cuchubal.rondaActual++;
-			cuchubal.participantesPagados = 0;
-		}
-	}
+        if (cuchubal.participantesPagados == cuchubal.numParticipantes) {
+            distributePayment(codigo);
+        }
+    }
 
-	function getCuchubalesByCreator(
-		address creator
-	) public view returns (string[] memory) {
-		return creatorToCuchubales[creator];
-	}
+    function distributePayment(string memory codigo) private {
+        Cuchubal storage cuchubal = cuchubales[codigo];
+        uint256 totalAmount = cuchubal.montoPorRonda * cuchubal.numParticipantes;
 
-	function getCuchubalInfo(
-		string memory codigo
-	)
-		public
-		view
-		returns (
-			string memory nombre,
-			uint256 montoPorRonda,
-			uint256 fechaInicio,
-			uint256 fechaFinalizacion,
-			uint256 numParticipantes,
-			uint256 rondaActual
-		)
-	{
-		Cuchubal storage cuchubal = cuchubales[codigo];
-		return (
-			cuchubal.nombre,
-			cuchubal.montoPorRonda,
-			cuchubal.fechaInicio,
-			cuchubal.fechaFinalizacion,
-			cuchubal.numParticipantes,
-			cuchubal.rondaActual
-		);
-	}
+        // Seleccionar ganador
+        if (cuchubal.participantesPagados == cuchubal.numParticipantes) {
+            uint256 randIndex =
+                uint256(keccak256(abi.encodePacked(block.timestamp, block.difficulty))) % cuchubal.numParticipantes;
+            address winner = cuchubal.participantIndex[randIndex + 1]; // Índice comienza en 1
 
-	function getParticipantsPaid(
-		string memory codigo
-	) public view returns (address[] memory, Participant[] memory) {
-		Cuchubal storage cuchubal = cuchubales[codigo];
-		address[] memory addresses = new address[](
-			cuchubal.participantesPagados
-		);
-		Participant[] memory participants = new Participant[](
-			cuchubal.participantesPagados
-		);
-		for (uint256 i = 1; i <= cuchubal.participantesPagados; i++) {
-			address participantAddr = cuchubal.participantIndex[i];
-			addresses[i - 1] = participantAddr;
-			participants[i - 1] = cuchubal.participants[participantAddr];
-		}
-		return (addresses, participants);
-	}
+            // Transferir al ganador
+            (bool success,) = payable(winner).call{value: totalAmount}("");
+            require(success, "Transfer failed.");
 
-	function getParticipants(
-		string memory codigo
-	) public view returns (address[] memory, Participant[] memory) {
-		Cuchubal storage cuchubal = cuchubales[codigo];
-		uint256 totalParticipants = cuchubal.numParticipantes; // Obtener el total de participantes
+            cuchubal.rounds[cuchubal.rondaActual] = Round({winner: winner, hasWinner: true});
+            emit RoundCompleted(codigo, cuchubal.rondaActual, winner);
 
-		address[] memory addresses = new address[](totalParticipants);
-		Participant[] memory participants = new Participant[](
-			totalParticipants
-		);
+            // Restablecer pagos para la siguiente ronda
+            for (uint256 i = 1; i <= cuchubal.numParticipantes; i++) {
+                address participantAddr = cuchubal.participantIndex[i];
+                cuchubal.participants[participantAddr].hasPaid = false;
+            }
 
-		for (uint256 i = 1; i <= totalParticipants; i++) {
-			address participantAddr = cuchubal.participantIndex[i];
-			addresses[i - 1] = participantAddr;
-			participants[i - 1] = cuchubal.participants[participantAddr];
-		}
+            cuchubal.participantesPagados = 0;
 
-		return (addresses, participants);
-	}
+            if (cuchubal.rondaActual < cuchubal.numParticipantes) {
+                cuchubal.rondaActual++;
+                cuchubal.participantesPagados = 0;
+            }
+        }
+    }
 
-	function getRoundHistory(
-		string memory codigo
-	) public view returns (Round[] memory) {
-		Cuchubal storage cuchubal = cuchubales[codigo];
-		Round[] memory rounds = new Round[](cuchubal.rondaActual);
-		for (uint256 i = 1; i <= cuchubal.rondaActual; i++) {
-			rounds[i - 1] = cuchubal.rounds[i];
-		}
-		return rounds;
-	}
+    function getCuchubalesByCreator(address creator) public view returns (string[] memory) {
+        return creatorToCuchubales[creator];
+    }
+
+    function getCuchubalInfo(string memory codigo)
+        public
+        view
+        returns (
+            string memory nombre,
+            uint256 montoPorRonda,
+            uint256 numParticipantes,
+            uint256 rondaActual
+        )
+    {
+        Cuchubal storage cuchubal = cuchubales[codigo];
+        return (
+            cuchubal.nombre,
+            cuchubal.montoPorRonda,
+            cuchubal.numParticipantes,
+            cuchubal.rondaActual
+        );
+    }
+
+    function getParticipantsPaid(string memory codigo) public view returns (address[] memory, Participant[] memory) {
+        Cuchubal storage cuchubal = cuchubales[codigo];
+        address[] memory addresses = new address[](cuchubal.participantesPagados);
+        Participant[] memory participants = new Participant[](cuchubal.participantesPagados);
+        for (uint256 i = 1; i <= cuchubal.participantesPagados; i++) {
+            address participantAddr = cuchubal.participantIndex[i];
+            addresses[i - 1] = participantAddr;
+            participants[i - 1] = cuchubal.participants[participantAddr];
+        }
+        return (addresses, participants);
+    }
+
+    function getParticipants(string memory codigo) public view returns (address[] memory, Participant[] memory) {
+        Cuchubal storage cuchubal = cuchubales[codigo];
+        uint256 totalParticipants = cuchubal.numParticipantes;
+
+        address[] memory addresses = new address[](totalParticipants);
+        Participant[] memory participants = new Participant[](totalParticipants);
+
+        for (uint256 i = 1; i <= totalParticipants; i++) {
+            address participantAddr = cuchubal.participantIndex[i];
+            addresses[i - 1] = participantAddr;
+            participants[i - 1] = cuchubal.participants[participantAddr];
+        }
+
+        return (addresses, participants);
+    }
+
+    function getRoundHistory(string memory codigo) public view returns (Round[] memory) {
+        Cuchubal storage cuchubal = cuchubales[codigo];
+        Round[] memory rounds = new Round[](cuchubal.rondaActual);
+        for (uint256 i = 1; i <= cuchubal.rondaActual; i++) {
+            rounds[i - 1] = cuchubal.rounds[i];
+        }
+        return rounds;
+    }
 }


### PR DESCRIPTION
Se deben separar las funciones joinCuchubal y payForNextRound para mayor modularidad de las funciones y que cumplan con el principio de responsabilidad única.

Se deberán ajustar los siguientes detalles también:

- Validar que cada cuchubal tenga un código de invitación único.
- Eliminar los campos relacionados a las fechas.

[User story](https://cuchulinkplatform.atlassian.net/browse/SC-87)